### PR TITLE
remove unimplemented --sort flag

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,6 @@ Options:
   -h, --help    Show this help message.
   --width=<n>   Restrict output to <n> characters. [default: 80]
   --bar=<char>  Use <char> to draw the bars. [default: █]
-  --sort        Sort the list in descending order.
 
 Input format:
   <count> <text>


### PR DESCRIPTION
It's not clear what --sort should do, and users can always sort the input themselves.

Close: https://github.com/jez/barchart/issues/10